### PR TITLE
Included mutex in ekf header

### DIFF
--- a/include/x/ekf/ekf.h
+++ b/include/x/ekf/ekf.h
@@ -19,6 +19,7 @@
 
 #include <optional>
 #include <thread>
+#include <mutex>
 
 #include "x/common/types.h"
 #include "x/ekf/propagator.h"

--- a/src/x/vio/vio.cpp
+++ b/src/x/vio/vio.cpp
@@ -201,7 +201,7 @@ void VIO::setUp(const Params &params) {
                  ci_slam_w, params_.iekf_iter);
 
   // EKF setup
-  const size_t state_buffer_sz = 250;  // TODO(jeff) Read from params
+  const size_t state_buffer_sz = params_.state_buffer_size;
   const State default_state = State(n_poses_state, n_features_state);
   const double a_m_max = 50.0;
   const unsigned int delta_seq_imu = 1;
@@ -546,7 +546,7 @@ std::optional<State> VIO::processOtherMeasurements(
 #endif
 
 
-Params loadParamsFromYaml(fsm::path& filePath) {
+Params VIO::loadParamsFromYaml(fsm::path& filePath) {
   std::cout << filePath.string() << std::endl;
   cv::FileStorage file(filePath.string(), cv::FileStorage::READ);
   Params params;

--- a/src/x/vision/tracker.cpp
+++ b/src/x/vision/tracker.cpp
@@ -298,7 +298,8 @@ void Tracker::track(TiledImage &current_img, const double &timestamp,
 
   previous_features_ = current_features;
   previous_timestamp_ = timestamp;
-  previous_img_ = current_img;
+  // Copy data
+  previous_img_ = current_img.clone(); 
 
 #ifdef PHOTOMETRIC_CALI
   current_img_origin_.copyTo(prev_img_origin_);


### PR DESCRIPTION
### Include mutex line
When following the installation instructions for [x_multi_agent](https://github.com/jpl-x/x_multi_agent), I am unable to build because **mutex** is not included in the [ekf.h](https://github.com/jpl-x/x_multi_agent/blob/main/include/x/ekf/ekf.h) header file for the X library. I am running Ubuntu 20.04 with ROS Noetic and have installed the required Ceres, NLopt, and OpenCV dependencies.

There are inline references to std::mutex at [ekf.h Line 178](https://github.com/jpl-x/x_multi_agent/blob/main/include/x/ekf/ekf.h#L178), [ekf.cpp Line 217](https://github.com/jpl-x/x_multi_agent/blob/main/src/x/ekf/ekf.cpp#L217), and [ekf.cpp Line 223](https://github.com/jpl-x/x_multi_agent/blob/main/src/x/ekf/ekf.cpp#L223). However, mutex is not declared in the header file, resulting in the compilation error: 

**error: 'mutex_' was not declared in this scope**

To fix this, I added the include mutex line to *ekf.h* in this fork, found [here](https://github.com/cmanore25/x_multi_agent/blob/main/include/x/ekf/ekf.h#L22). This resolves the compilation error and finishes the build successfully. 

Please test and see if you can reproduce this issue/fix, as I am sure others may encounter this issue in the future. I have not tested other X repositories yet to see if they have the same mutex issue, as this is the first one I have started to work with.

Cheers,
Curtis