### PR TITLE
Reproduce photometric calibration results. Needs fix for data race 

### DIFF
--- a/src/x/vio/vio_updater.cpp
+++ b/src/x/vio/vio_updater.cpp
@@ -185,6 +185,16 @@ void VioUpdater::preProcess(const State &state) {
   msckf_matches_ = tracker_.getMsckfMatches();
   tracker_.updateOppMatches(msckf_trks_, slam_trks_, opp_tmp);
 #endif
+  
+#ifdef PHOTOMETRIC_CALI
+  // TODO fix data race (?)
+  TrackList all_tracks = TrackList();
+  TrackList opp_tracks = track_manager_.getOppTracks();
+  all_tracks.insert(all_tracks.end(), slam_trks_.begin(), slam_trks_.end());
+  all_tracks.insert(all_tracks.end(), msckf_trks_.begin(), msckf_trks_.end());
+  all_tracks.insert(all_tracks.end(), opp_tracks.begin(), opp_tracks.end());
+  tracker_.setIntensistyHistory(all_tracks);
+#endif
 }
 
 bool VioUpdater::preUpdate(State &state) {


### PR DESCRIPTION
Address the issue: #4 
Recorrect the photometric parameters estimates with the intensity history our of the tracks.