### PR TITLE
Mutex include line added to place recognition header file

### DIFF
--- a/include/x/place_recognition/place_recognition.h
+++ b/include/x/place_recognition/place_recognition.h
@@ -25,6 +25,7 @@
 #include <opencv2/core/types.hpp>
 #include <opencv2/features2d.hpp>
 #include <thread>
+#include <mutex>
 
 #include "x/ekf/simple_state.h"
 #include "x/place_recognition/database.h"

--- a/include/x/vio/vio.h
+++ b/include/x/vio/vio.h
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <mutex>
 
 #include "x/common/types.h"
 #include "x/ekf/ekf.h"


### PR DESCRIPTION
Hello,

After pulling recent changes to x_multi_agent and experimenting with the multi_uav setup, I found an additional mutex include line to be added to [place_recognition.h](https://github.com/jpl-x/x_multi_agent/blob/main/include/x/place_recognition/place_recognition.h). If the line is not included, I get very similar build errors to #2 

I didn't catch this bug the first time since I did not have the MULTI_UAV flag turned on. 

Let me know if this PR is replicable and valid. If so, feel free to merge if you would like.

Cheers,
Curtis